### PR TITLE
Add app name to layout title

### DIFF
--- a/src/views/layouts/main.php
+++ b/src/views/layouts/main.php
@@ -20,7 +20,7 @@ AppAsset::register($this);
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <?php $this->registerCsrfMetaTags() ?>
-    <title><?= Html::encode($this->title) ?></title>
+    <title><?= Html::encode($this->title . ' · ' . $this->app->name) ?></title>
     <?php $this->head() ?>
 </head>
 <body>


### PR DESCRIPTION
I decided to use [interpunct](https://en.wikipedia.org/wiki/Interpunct) as a separator, like, for example, GitHub and some other websites do.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
