### PR TITLE
Removed --dev option from composer install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
 install:
   - travis_retry composer self-update && composer --version
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
-  - travis_retry composer install --dev --prefer-dist --no-interaction
+  - travis_retry composer install --prefer-dist --no-interaction
 
 script:
   - ./vendor/bin/phpunit


### PR DESCRIPTION
Dev packages are installed by default. There is no need for this option.
See https://travis-ci.org/yiisoft/yii-base-web/jobs/546238056#L257
